### PR TITLE
Add sidekiq and redis nodes

### DIFF
--- a/lib/avalon/about.rb
+++ b/lib/avalon/about.rb
@@ -22,9 +22,11 @@ module Avalon
     autoload :DelayedJob,       "avalon/about/delayed_job"
     autoload :Matterhorn,       "avalon/about/matterhorn"
     autoload :MediaInfo,        "avalon/about/media_info"
+    autoload :Redis,            "avalon/about/redis"
     autoload :Resque,           "avalon/about/resque"
     autoload :ResqueScheduler,  "avalon/about/resque_scheduler"
     autoload :RTMPServer,       "avalon/about/rtmp_server"
+    autoload :Sidekiq,          "avalon/about/sidekiq"
     autoload :HLSServer,        "avalon/about/hls_server"
   end
 end

--- a/lib/avalon/about/redis.rb
+++ b/lib/avalon/about/redis.rb
@@ -1,0 +1,25 @@
+module Avalon
+  module About
+    class Redis < AboutPage::Configuration::Node
+      render_with 'generic_hash'
+
+      validates_each :status do |record, attr, value|
+        record.errors.add attr, ": Can't connect to Redis" unless value
+      end
+
+      def initialize(redis)
+        @redis = redis
+      end
+
+      def status
+        @redis.ping == "PONG"
+      rescue
+        false
+      end
+
+      def to_h
+        @redis.inspect
+      end
+    end
+  end
+end

--- a/lib/avalon/about/sidekiq.rb
+++ b/lib/avalon/about/sidekiq.rb
@@ -1,0 +1,25 @@
+module Avalon
+  module About
+    class Sidekiq < AboutPage::Configuration::Node
+      render_with 'generic_hash'
+
+      validates_each :status do |record, attr, value|
+        record.errors.add attr, ": Sidekiq process count does not match #{@process_count}" unless value
+      end
+
+      def initialize(numProcesses: 1)
+        @process_count = numProcesses
+      end
+
+      def status
+        ::Sidekiq::ProcessSet.new.size == @process_count
+      rescue
+        false
+      end
+
+      def to_h
+        ::Sidekiq::ProcessSet.new.as_json
+      end
+    end
+  end
+end


### PR DESCRIPTION
Avalon switched from resque to sidekiq a long time ago but never created a sidekiq monitor to replace the existing resque monitor.  This PR adds that as well as a redis monitor.  Sidekiq relies on redis but Avalon also uses redis for caching so it is useful to know if redis is down independent of sidekiq processes running with a good redis connection.